### PR TITLE
feat(primitives): add primitive data types tutorial page

### DIFF
--- a/05-primitive-data-types/primitive-data-types.css
+++ b/05-primitive-data-types/primitive-data-types.css
@@ -1,0 +1,53 @@
+
+.text-output {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  background: linear-gradient(135deg, #f5f5f5 0%, #e8e8e8 100%);
+  border-radius: var(--radius);
+  font-family: verdana, sans-serif;
+  font-size: 1rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.08);
+  transition: all 0.3s ease;
+  animation: slideIn 0.5s ease-out;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.text-output:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 8px rgba(0, 0, 0, 0.15), 0 3px 6px rgba(0, 0, 0, 0.1);
+}
+
+body.dark-mode .text-output {
+  background: linear-gradient(135deg, #333 0%, #444 100%);
+  color: #e0e0e0;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .text-output {
+    margin-top: 1rem;
+    padding: 1rem;
+    font-size: 0.9rem;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .text-output {
+    margin-top: 0.75rem;
+    padding: 0.75rem;
+    font-size: 0.8rem;
+  }
+}
+

--- a/05-primitive-data-types/primitive-data-types.css
+++ b/05-primitive-data-types/primitive-data-types.css
@@ -4,7 +4,7 @@
   padding: 1.5rem;
   background: linear-gradient(135deg, #f5f5f5 0%, #e8e8e8 100%);
   border-radius: var(--radius);
-  font-family: verdana, sans-serif;
+  font-family: var(--font-family-code);
   font-size: 1rem;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.08);
   transition: all 0.3s ease;

--- a/05-primitive-data-types/primitive-data-types.html
+++ b/05-primitive-data-types/primitive-data-types.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Learn about JavaScript primitive data types with detailed explanations and interactive code examples." />
+  <meta name="keywords" content="JavaScript, Primitive Data Types, Number, String, Boolean, Undefined, Null, Symbol, BigInt, Web Development" />
+  <meta name="author" content="Suraj Ingole" />
+  <meta name="robots" content="index, follow" />
+  <meta name="og:title" content="Primitive Data Types in JavaScript" />
+  <meta name="og:description" content="Master JavaScript's primitive data types with interactive examples and in-depth theory." />
+  <meta name="og:type" content="website" />
+  <meta name="og:url" content="https://yourwebsite.com/02-variables/primitive-data-types.html" />
+  <meta name="og:image" content="https://yourwebsite.com/images/favicon.ico" />
+  <title>Primitive Data Types in JavaScript</title>
+  <link rel="stylesheet" href="primitive-data-types.css" />
+  <link rel="stylesheet" href="../shared/base.css" />
+  <link rel="stylesheet" href="../shared/page-default.css">
+  <link rel="icon" href="../images/favicon.ico" type="image/x-icon" />
+</head>
+<body>
+  <header>
+    <div class="container">
+      <h1>🌟 Primitive Data Types in JavaScript</h1>
+      <div class="header-controls">
+        <a class="back-button" href="../index.html">← Back to Home</a>
+        <button id="theme-toggle" aria-label="Toggle dark mode">🌙</button>
+      </div>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="theory">
+      <h2>Introduction to Primitive Data Types</h2>
+      <p>
+        In JavaScript, <strong>primitive data types</strong> are the basic building blocks of data. They are immutable (cannot be changed once created) and passed by value. JavaScript has seven primitive data types:
+      </p>
+      <ul>
+        <li><code>Number</code>: Represents both integers and floating-point numbers (e.g., <code>42</code>, <code>3.14</code>).</li>
+        <li><code>String</code>: Represents sequences of characters (e.g., <code>"Hello"</code>).</li>
+        <li><code>Boolean</code>: Represents <code>true</code> or <code>false</code>.</li>
+        <li><code>Undefined</code>: Represents a variable that has been declared but not assigned a value.</li>
+        <li><code>Null</code>: Represents the intentional absence of any value.</li>
+        <li><code>Symbol</code>: Represents unique and immutable identifiers, often used as object property keys.</li>
+        <li><code>BigInt</code>: Represents integers with arbitrary precision (e.g., <code>12345678901234567890n</code>).</li>
+      </ul>
+      <p>Unlike objects, primitives are immutable, meaning their values cannot be modified after creation (though variables holding them can be reassigned).</p>
+    </section>
+
+    <section class="code-example">
+      <h3>👉 Example: Exploring Primitive Types</h3>
+      <p>Click to see examples of all primitive data types and their <code>typeof</code> values.</p>
+      <button onclick="showPrimitiveTypes()">Show Primitive Types</button>
+      <div id="primitiveTypesOutput"></div>
+    </section>
+
+    <section class="theory">
+      <h2>Number and BigInt</h2>
+      <p>
+        The <code>Number</code> type represents both integers and floating-point numbers, but it has precision limits for very large numbers. <code>BigInt</code> was introduced to handle integers of arbitrary length, useful for calculations requiring high precision.
+      </p>
+      <p>
+        Common operations with <code>Number</code> include arithmetic (<code>+</code>, <code>-</code>, <code>*</code>, <code>/</code>), while <code>BigInt</code> requires special operators (e.g., <code>n</code> suffix for literals).
+      </p>
+    </section>
+
+    <section class="code-example">
+      <h3>👉 Example: Number vs. BigInt</h3>
+      <p>Click to see how <code>Number</code> and <code>BigInt</code> behave in calculations.</p>
+      <button onclick="showNumberBigInt()">Show Number & BigInt</button>
+      <div id="numberBigIntOutput"></div>
+    </section>
+
+    <section class="theory">
+      <h2>String and Type Coercion</h2>
+      <p>
+        The <code>String</code> type represents text and supports operations like concatenation and methods like <code>.toUpperCase()</code>. JavaScript’s <strong>type coercion</strong> often converts primitives to strings or numbers in operations, which can lead to unexpected results (e.g., <code>"5" + 3</code> yields <code>"53"</code>).
+      </p>
+    </section>
+
+    <section class="code-example">
+      <h3>👉 Example: String Operations and Coercion</h3>
+      <p>Click to explore string operations and type coercion.</p>
+      <button onclick="showStringCoercion()">Show String & Coercion</button>
+      <div id="stringCoercionOutput"></div>
+    </section>
+
+    <section class="theory">
+      <h2>Boolean, Undefined, Null, and Symbol</h2>
+      <p>
+        <code>Boolean</code> represents logical values (<code>true</code>/<code>false</code>). <code>Undefined</code> indicates an unassigned variable, while <code>Null</code> denotes the absence of a value. <code>Symbol</code> provides unique identifiers, often used for object keys to avoid naming conflicts.
+      </p>
+    </section>
+
+    <section class="code-example">
+      <h3>👉 Example: Boolean, Undefined, Null, Symbol</h3>
+      <p>Click to explore these primitive types and their behaviors.</p>
+      <button onclick="showOtherPrimitives()">Show Other Primitives</button>
+      <div id="otherPrimitivesOutput"></div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container">
+      <p>© 2025 JavaScript Full Stack Mastery. Built for learning purposes.</p>
+    </div>
+  </footer>
+  <script src="../shared/shared.js"></script>
+  <script src="primitive-data-types.js"></script>
+</body>
+</html>

--- a/05-primitive-data-types/primitive-data-types.html
+++ b/05-primitive-data-types/primitive-data-types.html
@@ -10,7 +10,7 @@
   <meta name="og:title" content="Primitive Data Types in JavaScript" />
   <meta name="og:description" content="Master JavaScript's primitive data types with interactive examples and in-depth theory." />
   <meta name="og:type" content="website" />
-  <meta name="og:url" content="https://yourwebsite.com/02-variables/primitive-data-types.html" />
+  <meta name="og:url" content="https://yourwebsite.com/05-primitive-data-types/primitive-data-types.html" />
   <meta name="og:image" content="https://yourwebsite.com/images/favicon.ico" />
   <title>Primitive Data Types in JavaScript</title>
   <link rel="stylesheet" href="primitive-data-types.css" />

--- a/05-primitive-data-types/primitive-data-types.js
+++ b/05-primitive-data-types/primitive-data-types.js
@@ -1,8 +1,10 @@
-document.addEventListener('DOMContentLoaded', () => {
-    const primitiveTypesOutput = document.getElementById('primitiveTypesOutput');
-    const numberBigIntOutput = document.getElementById('numberBigIntOutput');
-    const stringCoercionOutput = document.getElementById('stringCoercionOutput');
-    const otherPrimitivesOutput = document.getElementById('otherPrimitivesOutput');
+document.addEventListener("DOMContentLoaded", () => {
+  const primitiveTypesOutput = document.getElementById("primitiveTypesOutput");
+  const numberBigIntOutput = document.getElementById("numberBigIntOutput");
+  const stringCoercionOutput = document.getElementById("stringCoercionOutput");
+  const otherPrimitivesOutput = document.getElementById(
+    "otherPrimitivesOutput"
+  );
 
   // Primitive Types Example
   window.showPrimitiveTypes = function () {
@@ -12,56 +14,66 @@ document.addEventListener('DOMContentLoaded', () => {
       <p><strong>Boolean:</strong> true (typeof: ${typeof true})</p>
       <p><strong>Undefined:</strong> ${undefined} (typeof: ${typeof undefined})</p>
       <p><strong>Null:</strong> ${null} (typeof: ${typeof null})</p>
-      <p><strong>Symbol:</strong> Symbol("id") (typeof: ${typeof Symbol("id")})</p>
+      <p><strong>Symbol:</strong> Symbol("id") (typeof: ${typeof Symbol(
+        "id"
+      )})</p>
       <p><strong>BigInt:</strong> 12345678901234567890n (typeof: ${typeof 12345678901234567890n})</p>
     `;
-    document.getElementById('primitiveTypesOutput').innerHTML = output;
-    primitiveTypesOutput.classList.add('text-output');
+    primitiveTypesOutput.innerHTML = output;
+    primitiveTypesOutput.classList.add("text-output");
   };
 
   // Number vs. BigInt Example
   window.showNumberBigInt = function () {
     const largeNumber = 9007199254740991; // Max safe integer for Number
-    const bigIntNumber = 9007199254740991n;a
+    const bigIntNumber = 9007199254740991n;
     const output = `
       <p><strong>Number:</strong> ${largeNumber} (typeof: ${typeof largeNumber})</p>
       <p><strong>Number + 1:</strong> ${largeNumber + 1} (precision issue)</p>
       <p><strong>BigInt:</strong> ${bigIntNumber} (typeof: ${typeof bigIntNumber})</p>
       <p><strong>BigInt + 1n:</strong> ${bigIntNumber + 1n} (exact)</p>
-      <p><strong>Number * 2:</strong> ${largeNumber * 2} (may lose precision)</p>
+      <p><strong>Number * 2:</strong> ${
+        largeNumber * 2
+      } (may lose precision)</p>
       <p><strong>BigInt * 2n:</strong> ${bigIntNumber * 2n} (exact)</p>
     `;
-    document.getElementById('numberBigIntOutput').innerHTML = output;
-    numberBigIntOutput.classList.add('text-output');
+    numberBigIntOutput.innerHTML = output;
+    numberBigIntOutput.classList.add("text-output");
   };
 
   // String Operations and Coercion Example
   window.showStringCoercion = function () {
     const output = `
-      <p><strong>String Concatenation:</strong> "Hello" + " World" = "${"Hello" + " World"}"</p>
+      <p><strong>String Concatenation:</strong> "Hello" + " World" = "${
+        "Hello" + " World"
+      }"</p>
       <p><strong>String Method:</strong> "hello".toUpperCase() = "${"hello".toUpperCase()}"</p>
       <p><strong>Coercion (+):</strong> "5" + 3 = "${"5" + 3}"</p>
       <p><strong>Coercion (*):</strong> "5" * 3 = ${"5" * 3}</p>
       <p><strong>Coercion (==):</strong> "5" == 5 = ${"5" == 5}</p>
       <p><strong>Coercion (===):</strong> "5" === 5 = ${"5" === 5}</p>
     `;
-    document.getElementById('stringCoercionOutput').innerHTML = output;
-    stringCoercionOutput.classList.add('text-output');
+    stringCoercionOutput.innerHTML = output;
+    stringCoercionOutput.classList.add("text-output");
   };
 
   // Boolean, Undefined, Null, Symbol Example
   window.showOtherPrimitives = function () {
-    const sym1 = Symbol('id');
-    const sym2 = Symbol('id');
+    const sym1 = Symbol("id");
+    const sym2 = Symbol("id");
     const output = `
       <p><strong>Boolean:</strong> true (typeof: ${typeof true})</p>
-      <p><strong>Boolean Operation:</strong> true && false = ${true && false}</p>
+      <p><strong>Boolean Operation:</strong> true && false = ${
+        true && false
+      }</p>
       <p><strong>Undefined:</strong> ${undefined} (typeof: ${typeof undefined})</p>
       <p><strong>Null:</strong> ${null} (typeof: ${typeof null})</p>
       <p><strong>Symbol:</strong> Symbol("id") (typeof: ${typeof sym1})</p>
-      <p><strong>Symbol Uniqueness:</strong> Symbol('id') === Symbol('id') = ${sym1 === sym2}</p>
+      <p><strong>Symbol Uniqueness:</strong> Symbol('id') === Symbol('id') = ${
+        sym1 === sym2
+      }</p>
     `;
-    document.getElementById('otherPrimitivesOutput').innerHTML = output;
-    otherPrimitivesOutput.classList.add('text-output');
+    otherPrimitivesOutput.innerHTML = output;
+    otherPrimitivesOutput.classList.add("text-output");
   };
 });

--- a/05-primitive-data-types/primitive-data-types.js
+++ b/05-primitive-data-types/primitive-data-types.js
@@ -1,0 +1,67 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const primitiveTypesOutput = document.getElementById('primitiveTypesOutput');
+    const numberBigIntOutput = document.getElementById('numberBigIntOutput');
+    const stringCoercionOutput = document.getElementById('stringCoercionOutput');
+    const otherPrimitivesOutput = document.getElementById('otherPrimitivesOutput');
+
+  // Primitive Types Example
+  window.showPrimitiveTypes = function () {
+    const output = `
+      <p><strong>Number:</strong> 42 (typeof: ${typeof 42})</p>
+      <p><strong>String:</strong> "Hello, World!" (typeof: ${typeof "Hello, World!"})</p>
+      <p><strong>Boolean:</strong> true (typeof: ${typeof true})</p>
+      <p><strong>Undefined:</strong> ${undefined} (typeof: ${typeof undefined})</p>
+      <p><strong>Null:</strong> ${null} (typeof: ${typeof null})</p>
+      <p><strong>Symbol:</strong> Symbol("id") (typeof: ${typeof Symbol("id")})</p>
+      <p><strong>BigInt:</strong> 12345678901234567890n (typeof: ${typeof 12345678901234567890n})</p>
+    `;
+    document.getElementById('primitiveTypesOutput').innerHTML = output;
+    primitiveTypesOutput.classList.add('text-output');
+  };
+
+  // Number vs. BigInt Example
+  window.showNumberBigInt = function () {
+    const largeNumber = 9007199254740991; // Max safe integer for Number
+    const bigIntNumber = 9007199254740991n;a
+    const output = `
+      <p><strong>Number:</strong> ${largeNumber} (typeof: ${typeof largeNumber})</p>
+      <p><strong>Number + 1:</strong> ${largeNumber + 1} (precision issue)</p>
+      <p><strong>BigInt:</strong> ${bigIntNumber} (typeof: ${typeof bigIntNumber})</p>
+      <p><strong>BigInt + 1n:</strong> ${bigIntNumber + 1n} (exact)</p>
+      <p><strong>Number * 2:</strong> ${largeNumber * 2} (may lose precision)</p>
+      <p><strong>BigInt * 2n:</strong> ${bigIntNumber * 2n} (exact)</p>
+    `;
+    document.getElementById('numberBigIntOutput').innerHTML = output;
+    numberBigIntOutput.classList.add('text-output');
+  };
+
+  // String Operations and Coercion Example
+  window.showStringCoercion = function () {
+    const output = `
+      <p><strong>String Concatenation:</strong> "Hello" + " World" = "${"Hello" + " World"}"</p>
+      <p><strong>String Method:</strong> "hello".toUpperCase() = "${"hello".toUpperCase()}"</p>
+      <p><strong>Coercion (+):</strong> "5" + 3 = "${"5" + 3}"</p>
+      <p><strong>Coercion (*):</strong> "5" * 3 = ${"5" * 3}</p>
+      <p><strong>Coercion (==):</strong> "5" == 5 = ${"5" == 5}</p>
+      <p><strong>Coercion (===):</strong> "5" === 5 = ${"5" === 5}</p>
+    `;
+    document.getElementById('stringCoercionOutput').innerHTML = output;
+    stringCoercionOutput.classList.add('text-output');
+  };
+
+  // Boolean, Undefined, Null, Symbol Example
+  window.showOtherPrimitives = function () {
+    const sym1 = Symbol('id');
+    const sym2 = Symbol('id');
+    const output = `
+      <p><strong>Boolean:</strong> true (typeof: ${typeof true})</p>
+      <p><strong>Boolean Operation:</strong> true && false = ${true && false}</p>
+      <p><strong>Undefined:</strong> ${undefined} (typeof: ${typeof undefined})</p>
+      <p><strong>Null:</strong> ${null} (typeof: ${typeof null})</p>
+      <p><strong>Symbol:</strong> Symbol("id") (typeof: ${typeof sym1})</p>
+      <p><strong>Symbol Uniqueness:</strong> Symbol('id') === Symbol('id') = ${sym1 === sym2}</p>
+    `;
+    document.getElementById('otherPrimitivesOutput').innerHTML = output;
+    otherPrimitivesOutput.classList.add('text-output');
+  };
+});

--- a/index.html
+++ b/index.html
@@ -85,6 +85,15 @@
                 >var, let, and const</a
               >
             </li>
+            <li>
+              <a
+                href="05-primitive-data-types/primitive-data-types.html"
+                target="_blank"
+                title="Primitive Data Types"
+                referrerpolicy="no-referrer noopener"
+                >Primitive Data Types</a
+              >
+            </li>
           </ul>
         </div>
         <div class="card">

--- a/summary.md
+++ b/summary.md
@@ -281,13 +281,13 @@ JavaScript is a dynamically typed language, meaning you don't have to explicitly
         
         ```
 
-    - **`BigInt`** (ES2020): Represents whole numbers larger than `2^53 - 1`, which is the largest number JavaScript can reliably represent with the 
-        `Number` type.
+- **`BigInt`** (ES2020): Represents whole numbers larger than `2^53 - 1`, which is the largest number JavaScript can reliably represent with the `Number` type.
 
-        ```javascript
-        const largeNumber = 9007199254740991n; // 'n' suffix makes it a BigInt
-        
-        ```
+    ```javascript
+        const largeNumber = 9007199254740991n; // 'n' suffix makes it a BigInt  
+        console.log(largeNumber); // Output: 9007199254740991n
+
+    ```
 
 2.**Non-Primitive (Reference) Value:**
 
@@ -579,3 +579,346 @@ console.log(numbers); // Output: [1, 2, 3, 4]
 | **Re-assignment**  | Yes                         | Yes                                        | No (for primitive values; allowed for objects/arrays)  |
 | **Initialization** | Optional                   | Optional                                   | Required                                               |
 | **Best Practice**  | Avoid in new code           | Use when value changes                     | Use when value is constant                             |
+
+## 5.  Primitive Data Types in JavaScript
+
+JavaScript categorizes data into two main types: **primitive** and **non-primitive (or object)**. Primitive data types are fundamental, immutable values that are not objects and have no methods. When you assign a primitive value to a variable, you're directly storing that value.
+
+There are seven primitive data types in JavaScript:
+
+1. `string`
+2. `number`
+3. `bigint`
+4. `boolean`
+5. `undefined`
+6. `symbol`
+7. `null`
+
+Let's explore each one in detail with examples.
+
+### 1. `string`
+
+A `string` represents a sequence of characters, such as text. Strings are immutable, meaning once a string is created, its content cannot be changed. Any operation that appears to modify a string actually creates a new string.
+
+**Characteristics:**
+
+- Enclosed in single quotes (`'...'`), double quotes (`"..."`), or backticks (`` `...` ``).
+- Backticks allow for template literals, which support embedded expressions (interpolation) and multi-line strings.
+
+**Examples:**
+
+```javascript
+// Single quotes
+let firstName = 'John';
+console.log(typeof firstName); // Output: "string"
+
+// Double quotes
+let lastName = "Doe";
+console.log(typeof lastName);  // Output: "string"
+
+// Template literals (backticks)
+let greeting = `Hello, ${firstName} ${lastName}!`;
+console.log(greeting); // Output: "Hello, John Doe!"
+
+let multiLineString = `This is a
+multi-line
+string.`;
+console.log(multiLineString);
+
+// Immutability example
+let originalString = "hello";
+originalString.toUpperCase(); // This does NOT change originalString
+console.log(originalString); // Output: "hello"
+
+let newString = originalString.toUpperCase();
+console.log(newString);     // Output: "HELLO"
+
+```
+
+### 2. `number`
+
+The `number` type represents both integer and floating-point numbers. JavaScript uses a 64-bit floating-point format (IEEE 754 standard).
+
+**Characteristics:**
+
+-   Supports standard arithmetic operations.
+    
+-   Special numeric values: `Infinity` (positive infinity), `-Infinity` (negative infinity), and `NaN` (Not-a-Number). `NaN` results from invalid mathematical operations (e.g., `0 / 0`).
+    
+
+**Examples:**
+
+```javascript
+// Integer
+let age = 30;
+console.log(typeof age); // Output: "number"
+
+// Floating-point number
+let price = 19.99;
+console.log(typeof price); // Output: "number"
+
+// Arithmetic operations
+let sum = age + price;
+console.log(sum); // Output: 49.99
+
+// Special numeric values
+let result1 = 10 / 0;
+console.log(result1); // Output: Infinity
+
+let result2 = -10 / 0;
+console.log(result2); // Output: -Infinity
+
+let result3 = "hello" / 2;
+console.log(result3); // Output: NaN
+console.log(typeof result3); // Output: "number" (NaN is still a number type)
+
+```
+
+### 3. `bigint`
+
+`bigint` is a relatively new primitive type (introduced in ES2020) that can represent whole numbers larger than 253−1 (the maximum safe integer for `number` type) or smaller than −(253−1).
+
+**Characteristics:**
+
+-   Created by appending `n` to an integer literal or by calling the `BigInt()` constructor.
+    
+-   Cannot be mixed with `number` types in arithmetic operations directly. You must convert one to the other explicitly.
+    
+
+**Examples:**
+
+```javascript
+// Creating a BigInt
+let largeNumber = 9007199254740991n; // Appending 'n'
+console.log(typeof largeNumber); // Output: "bigint"
+
+let evenLargerNumber = BigInt("9007199254740991234567890");
+console.log(evenLargerNumber); // Output: 9007199254740991234567890n
+
+// Regular number vs BigInt
+let maxSafeInteger = Number.MAX_SAFE_INTEGER;
+console.log(maxSafeInteger); // Output: 9007199254740991
+
+let beyondSafe = maxSafeInteger + 1;
+console.log(beyondSafe); // Output: 9007199254740992 (accurate)
+
+let beyondSafePlusOne = maxSafeInteger + 2;
+console.log(beyondSafePlusOne); // Output: 9007199254740992 (inaccurate due to precision limits)
+
+let correctBeyondSafePlusOne = BigInt(maxSafeInteger) + 2n;
+console.log(correctBeyondSafePlusOne); // Output: 9007199254740993n (accurate)
+
+// Cannot mix BigInt and Number directly
+// let mixedSum = largeNumber + 10; // Throws TypeError: Cannot mix BigInt and other types
+
+let convertedSum = largeNumber + BigInt(10);
+console.log(convertedSum); // Output: 9007199254741001n
+
+```
+
+### 4. `boolean`
+
+The `boolean` type represents a logical entity and can have only two values: `true` or `false`. It is fundamental for conditional logic.
+
+**Characteristics:**
+
+-   Used in conditional statements (`if`, `else if`, `else`), loops (`for`, `while`), and logical operations (`&&`, `||`, `!`).
+    
+-   Many values can be implicitly converted to booleans in a "truthy" or "falsy" context.
+    
+
+**Falsy Values:**
+
+-   `false`
+    
+-   `0` (number zero)
+    
+-   `-0` (negative zero)
+    
+-   `0n` (BigInt zero)
+    
+-   `""` (empty string)
+    
+-   `null`
+    
+-   `undefined`
+    
+-   `NaN`
+    
+
+All other values are considered "truthy."
+
+**Examples:**
+
+```javascript
+let isActive = true;
+console.log(typeof isActive); // Output: "boolean"
+
+let hasPermission = false;
+console.log(typeof hasPermission); // Output: "boolean"
+
+if (isActive) {
+    console.log("User is active.");
+} else {
+    console.log("User is inactive.");
+}
+
+// Truthy and Falsy examples
+if ("hello") { // "hello" is truthy
+    console.log("This will run.");
+}
+
+if (0) { // 0 is falsy
+    console.log("This will NOT run.");
+}
+
+if ([]) { // Empty array is truthy (even though it's empty)
+    console.log("Empty array is truthy.");
+}
+
+if ({}) { // Empty object is truthy
+    console.log("Empty object is truthy.");
+}
+
+```
+
+###  5. `undefined`
+
+The `undefined` type signifies that a variable has been declared but has not yet been assigned a value. It's also the default return value for functions that don't explicitly return anything.
+
+**Characteristics:**
+
+-   Automatically assigned to newly declared variables that are not initialized.
+    
+-   A function that doesn't have a `return` statement explicitly returns `undefined`.
+    
+-   Accessing a non-existent object property also yields `undefined`.
+    
+
+**Examples:**
+
+```javascript
+let myVariable; // Declared but not initialized
+console.log(myVariable); // Output: undefined
+console.log(typeof myVariable); // Output: "undefined"
+
+function doNothing() {
+    // No return statement
+}
+let result = doNothing();
+console.log(result); // Output: undefined
+
+let myObject = {
+    name: "Alice"
+};
+console.log(myObject.age); // Output: undefined (property 'age' does not exist)
+
+// Comparing with undefined
+console.log(myVariable === undefined); // Output: true
+
+```
+
+###  6. `symbol`
+
+The `symbol` type (introduced in ES6/ES2015) is a unique and immutable data type that can be used as the key of an object property. Each `Symbol` value is unique, even if created with the same description.
+
+**Characteristics:**
+
+-   Created using the `Symbol()` constructor (not `new Symbol()`).
+    
+-   Primarily used to create unique object property keys to avoid name collisions, especially when extending objects or working with third-party code.
+    
+-   Symbols are not enumerable by `for...in` loops or `Object.keys()`, `Object.values()`, `Object.entries()`. They can be found using `Object.getOwnPropertySymbols()`.
+    
+
+**Examples:**
+
+```javascript
+// Creating Symbols
+const id1 = Symbol('id');
+const id2 = Symbol('id');
+
+console.log(id1);        // Output: Symbol(id)
+console.log(id2);        // Output: Symbol(id)
+console.log(id1 === id2); // Output: false (they are unique)
+console.log(typeof id1); // Output: "symbol"
+
+// Using Symbols as object keys
+let user = {
+    name: "Bob",
+    [id1]: 123
+};
+
+user[id2] = 456; // This creates a new property with a different Symbol key
+
+console.log(user);
+// Output: { name: 'Bob', [Symbol(id)]: 123, [Symbol(id)]: 456 }
+
+console.log(user[id1]); // Output: 123
+console.log(user[id2]); // Output: 456
+
+// Symbols are not enumerated by standard methods
+for (let key in user) {
+    console.log(key); // Output: name
+}
+
+console.log(Object.keys(user)); // Output: ["name"]
+console.log(Object.getOwnPropertySymbols(user)); // Output: [Symbol(id), Symbol(id)]
+
+```
+
+## 7. `null`
+
+The `null` type represents the intentional absence of any object value. It is a primitive value.
+
+**Characteristics:**
+
+-   It's a "placeholder" for "no value" or "nothing."
+    
+-   It's often used to explicitly indicate that a variable currently holds no meaningful object reference.
+    
+-   A long-standing quirk in JavaScript is that `typeof null` returns `"object"`. This is a historical bug and does not mean `null` is an object.
+    
+
+**Examples:**
+
+```javascript
+let emptyValue = null;
+console.log(emptyValue); // Output: null
+console.log(typeof emptyValue); // Output: "object" (historical quirk, not an actual object)
+
+let userProfile = {
+    name: "Charlie",
+    email: "charlie@example.com",
+    phone: null // Explicitly indicating no phone number
+};
+
+console.log(userProfile.phone); // Output: null
+
+// Difference between null and undefined
+let a;
+let b = null;
+
+console.log(a == b);  // Output: true (loose equality, null and undefined are considered equal)
+console.log(a === b); // Output: false (strict equality, different types)
+
+```
+
+###  Immutability of Primitives
+
+A key concept for primitive types is their **immutability**. This means that the value itself cannot be changed after it's created. When you perform an operation that seems to modify a primitive, you are actually creating a _new_ primitive value.
+
+**Example:**
+
+```javascript
+let myString = "hello";
+myString = myString + " world"; // This doesn't modify "hello"; it creates a new string "hello world"
+                               // and assigns it to myString.
+
+let myNumber = 10;
+myNumber = myNumber + 5; // This doesn't modify 10; it creates a new number 15
+                         // and assigns it to myNumber.
+
+```
+
+Understanding primitive data types is fundamental to grasping how JavaScript manages values and memory, especially when contrasting them with non-primitive (object) types, which are mutable and passed by reference.

--- a/summary.md
+++ b/summary.md
@@ -405,8 +405,7 @@ Variables are used to store data values. Before using a variable, it must be dec
 - Avoid `var` in new code.
 - Understanding scope (`block` vs. `function`) is crucial for avoiding bugs.
 
-
-##  4. JavaScript Variable Declarations: `var`, `let`, and `const`
+## 4. JavaScript Variable Declarations: `var`, `let`, and `const`
 
 In JavaScript, variables are used to store data values. The way you declare a variable significantly impacts its **scope**, **hoisting behavior**, and whether it can be **re-declared** or **re-assigned**. Modern JavaScript (ES6 and later) introduced `let` and `const` to address some of the complexities and potential pitfalls associated with the older `var` keyword.
 
@@ -414,24 +413,18 @@ In JavaScript, variables are used to store data values. The way you declare a va
 
 `var` was the only way to declare variables in JavaScript before ES6. While still functional, it has certain characteristics that make it less predictable and prone to errors in larger codebases, leading to its general discouragement in modern development.
 
--   **Scope:**  `var` is **function-scoped**.
-    
-    -   If declared inside a function, it's local to that function and not accessible outside it.
-        
-    -   If declared outside any function, it's global and accessible throughout the entire script.
-        
-    -   Crucially, `var` does _not_ respect block scope (e.g., `if` blocks, `for` loops).
-        
--   **Hoisting:**  `var` declarations are "hoisted" to the top of their containing function or global scope during the compilation phase. This means the declaration is processed before the code execution.
-    
-    -   You can use a `var` variable before its physical declaration in the code. However, its value will be `undefined` until the line where it's assigned a value is executed.
-        
--   **Re-declaration:** A `var` variable can be re-declared within the same scope without causing an error. This can lead to accidental overwriting of variables.
-    
--   **Re-assignment:** A `var` variable can be re-assigned to a new value at any point after its declaration.
-    
--   **Recommendation:** Generally **discouraged** in modern JavaScript due to its confusing scoping rules and the potential for unexpected behavior, especially with hoisting and re-declaration.
-    
+1. **Scope:**  `var` is **function-scoped**.
+
+    - If declared inside a function, it's local to that function and not accessible outside it.
+    - If declared outside any function, it's global and accessible throughout the entire script.
+    - Crucially, `var` does _not_ respect block scope (e.g., `if` blocks, `for` loops).
+
+2. **Hoisting:**  `var` declarations are "hoisted" to the top of their containing function or global scope during the compilation phase. This means the declaration is processed before the code execution.
+
+    - You can use a `var` variable before its physical declaration in the code. However, its value will be `undefined` until the line where it's assigned a value is executed.
+    - **Re-declaration:** A `var` variable can be re-declared within the same scope without causing an error. This can lead to accidental overwriting of variables.
+    - **Re-assignment:** A `var` variable can be re-assigned to a new value at any point after its declaration.
+    - **Recommendation:** Generally **discouraged** in modern JavaScript due to its confusing scoping rules and the potential for unexpected behavior, especially with hoisting and re-declaration.
 
 **Example:**
 
@@ -641,10 +634,8 @@ The `number` type represents both integer and floating-point numbers. JavaScript
 
 **Characteristics:**
 
--   Supports standard arithmetic operations.
-    
--   Special numeric values: `Infinity` (positive infinity), `-Infinity` (negative infinity), and `NaN` (Not-a-Number). `NaN` results from invalid mathematical operations (e.g., `0 / 0`).
-    
+- Supports standard arithmetic operations.
+- Special numeric values: `Infinity` (positive infinity), `-Infinity` (negative infinity), and `NaN` (Not-a-Number). `NaN` results from invalid mathematical operations (e.g., `0 / 0`).
 
 **Examples:**
 
@@ -680,10 +671,8 @@ console.log(typeof result3); // Output: "number" (NaN is still a number type)
 
 **Characteristics:**
 
--   Created by appending `n` to an integer literal or by calling the `BigInt()` constructor.
-    
--   Cannot be mixed with `number` types in arithmetic operations directly. You must convert one to the other explicitly.
-    
+- Created by appending `n` to an integer literal or by calling the `BigInt()` constructor.
+- Cannot be mixed with `number` types in arithmetic operations directly. You must convert one to the other explicitly.
 
 **Examples:**
 
@@ -722,29 +711,19 @@ The `boolean` type represents a logical entity and can have only two values: `tr
 
 **Characteristics:**
 
--   Used in conditional statements (`if`, `else if`, `else`), loops (`for`, `while`), and logical operations (`&&`, `||`, `!`).
-    
--   Many values can be implicitly converted to booleans in a "truthy" or "falsy" context.
-    
+- Used in conditional statements (`if`, `else if`, `else`), loops (`for`, `while`), and logical operations (`&&`, `||`, `!`).
+- Many values can be implicitly converted to booleans in a "truthy" or "falsy" context.
 
 **Falsy Values:**
 
--   `false`
-    
--   `0` (number zero)
-    
--   `-0` (negative zero)
-    
--   `0n` (BigInt zero)
-    
--   `""` (empty string)
-    
--   `null`
-    
--   `undefined`
-    
--   `NaN`
-    
+- `false
+- `0` (number zero)
+- `-0` (negative zero)
+- `0n` (BigInt zero)
+- `""` (empty string)
+- `null`
+- `undefined`
+- `NaN`
 
 All other values are considered "truthy."
 
@@ -782,18 +761,15 @@ if ({}) { // Empty object is truthy
 
 ```
 
-###  5. `undefined`
+### 5. `undefined`
 
 The `undefined` type signifies that a variable has been declared but has not yet been assigned a value. It's also the default return value for functions that don't explicitly return anything.
 
 **Characteristics:**
 
--   Automatically assigned to newly declared variables that are not initialized.
-    
--   A function that doesn't have a `return` statement explicitly returns `undefined`.
-    
--   Accessing a non-existent object property also yields `undefined`.
-    
+- Automatically assigned to newly declared variables that are not initialized.
+- A function that doesn't have a `return` statement explicitly returns `undefined`.
+- Accessing a non-existent object property also yields `undefined`.
 
 **Examples:**
 
@@ -818,18 +794,15 @@ console.log(myVariable === undefined); // Output: true
 
 ```
 
-###  6. `symbol`
+### 6. `symbol`
 
 The `symbol` type (introduced in ES6/ES2015) is a unique and immutable data type that can be used as the key of an object property. Each `Symbol` value is unique, even if created with the same description.
 
 **Characteristics:**
 
--   Created using the `Symbol()` constructor (not `new Symbol()`).
-    
--   Primarily used to create unique object property keys to avoid name collisions, especially when extending objects or working with third-party code.
-    
--   Symbols are not enumerable by `for...in` loops or `Object.keys()`, `Object.values()`, `Object.entries()`. They can be found using `Object.getOwnPropertySymbols()`.
-    
+- Created using the `Symbol()` constructor (not `new Symbol()`).
+- Primarily used to create unique object property keys to avoid name collisions, especially when extending objects or working with third-party code.
+- Symbols are not enumerable by `for...in` loops or `Object.keys()`, `Object.values()`, `Object.entries()`. They can be found using `Object.getOwnPropertySymbols()`.
 
 **Examples:**
 
@@ -867,18 +840,15 @@ console.log(Object.getOwnPropertySymbols(user)); // Output: [Symbol(id), Symbol(
 
 ```
 
-## 7. `null`
+### 7. `null`
 
 The `null` type represents the intentional absence of any object value. It is a primitive value.
 
 **Characteristics:**
 
--   It's a "placeholder" for "no value" or "nothing."
-    
--   It's often used to explicitly indicate that a variable currently holds no meaningful object reference.
-    
--   A long-standing quirk in JavaScript is that `typeof null` returns `"object"`. This is a historical bug and does not mean `null` is an object.
-    
+- It's a "placeholder" for "no value" or "nothing."
+- It's often used to explicitly indicate that a variable currently holds no meaningful object reference.
+- A long-standing quirk in JavaScript is that `typeof null` returns `"object"`. This is a historical bug and does not mean `null` is an object.
 
 **Examples:**
 
@@ -904,7 +874,7 @@ console.log(a === b); // Output: false (strict equality, different types)
 
 ```
 
-###  Immutability of Primitives
+### Immutability of Primitives
 
 A key concept for primitive types is their **immutability**. This means that the value itself cannot be changed after it's created. When you perform an operation that seems to modify a primitive, you are actually creating a _new_ primitive value.
 


### PR DESCRIPTION
Add a comprehensive tutorial page explaining JavaScript primitive data types with interactive examples. Includes:
- HTML page with theory sections and interactive code examples
- CSS styling for code output sections with animations
- JavaScript demonstrating all primitive types with practical examples
- Updated summary.md with detailed documentation